### PR TITLE
fix readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ let
   packages = nixpkgs.beam.packagesWith nixpkgs.beam.interpreters.erlang;
 in
 
-packages.buildMix {
+packages.buildMix' {
   pname = "my-project";
   version = "1.2.3";
 }


### PR DESCRIPTION
the ' is missing in the readme install instructions.
That tripped me.

If you are open for it, I would suggest something a little easier to differentiate, like `buildMixProject`.
If it works for you, let me know and I'll make the change everywhere.