### PR TITLE
fetch only prod deps for prod env

### DIFF
--- a/lib/fetch-mix-deps.nix
+++ b/lib/fetch-mix-deps.nix
@@ -23,9 +23,7 @@ let
       '';
 
       buildPhase = ''
-        mix deps.get ${
-          stdenvNoCC.lib.optionalString (mixEnv == "prod") "--only-prod"
-        }
+        mix deps.get --only ${mixEnv}
         find "$out" -path '*/.git/*' -a ! -name HEAD -exec rm -rf {} +
       '';
 

--- a/lib/fetch-mix-deps.nix
+++ b/lib/fetch-mix-deps.nix
@@ -1,8 +1,7 @@
 { stdenvNoCC, elixir, hex, rebar, rebar3, git, cacert }:
 
 let
-  fetchMixDeps =
-    { name ? "mix", src, sha256, mixEnv ? "prod" }:
+  fetchMixDeps = { name ? "mix", src, sha256, mixEnv ? "prod" }:
     stdenvNoCC.mkDerivation {
       name = "${name}-deps";
 
@@ -24,7 +23,9 @@ let
       '';
 
       buildPhase = ''
-        mix deps.get
+        mix deps.get ${
+          stdenvNoCC.lib.optionalString (mixEnv == "prod") "--only-prod"
+        }
         find "$out" -path '*/.git/*' -a ! -name HEAD -exec rm -rf {} +
       '';
 


### PR DESCRIPTION
For prod environment, only prod deps should be fetched.

Let me know if anything doesn't make sense.

The first change was because I am using the automated formatter, let me know if you would rather revert that.