### PR TITLE
Remove deprecated use of `stdenv*.lib`

### DIFF
--- a/lib/fetch-mix-deps.nix
+++ b/lib/fetch-mix-deps.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, elixir, hex, rebar, rebar3, git, cacert }:
+{ stdenvNoCC, lib, elixir, hex, rebar, rebar3, git, cacert }:
 
 let
   fetchMixDeps = { name ? "mix", src, sha256, mixEnv ? "prod" }:
@@ -33,6 +33,6 @@ let
       outputHashMode = "recursive";
       outputHash = sha256;
 
-      impureEnvVars = stdenvNoCC.lib.fetchers.proxyImpureEnvVars;
+      impureEnvVars = lib.fetchers.proxyImpureEnvVars;
     };
 in fetchMixDeps


### PR DESCRIPTION
In current versions of nix or nixpkgs there is a trace message on
usage of `stdenv*.lib` that warns about deprecation of `stdenv.lib`
and future removal of the mentioned attribute.

It suggests to use top-level `lib` instead.