### PR TITLE
Add flake support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,7 @@
+{
+  description = "Simple Nixpkgs overlay for building Mix releases";
+
+  outputs = { self }: {
+    overlays.default = import ./.;
+  };
+}


### PR DESCRIPTION
This PR adds flake support for `nix-elixir`, exposing the overlay provided in `default.nix` as a flake output.
